### PR TITLE
Fix #23 issue. Add socket timeout for each recv call.

### DIFF
--- a/source/device/client.py
+++ b/source/device/client.py
@@ -1,16 +1,16 @@
-from ..pcic import O2x5xxPCICDevice
+from ..pcic import (O2x5xxPCICDevice, SOCKET_TIMEOUT)
 from ..rpc import O2x5xxRPCDevice
 
 
 class O2x5xxDevice(O2x5xxPCICDevice):
-    def __init__(self, address="192.168.0.69", port=50010, autoconnect=True):
+    def __init__(self, address="192.168.0.69", port=50010, autoconnect=True, timeout=SOCKET_TIMEOUT):
         self._address = address
         self._port = port
         self._autoconnect = autoconnect
         self._rpc = None
         if autoconnect:
             self._rpc = O2x5xxRPCDevice(address=self._address)
-        super(O2x5xxPCICDevice, self).__init__(address, port, autoconnect)
+        super(O2x5xxPCICDevice, self).__init__(address, port, autoconnect, timeout)
 
     def __enter__(self):
         return self
@@ -27,15 +27,17 @@ class O2x5xxDevice(O2x5xxPCICDevice):
 
 
 class O2x5xxDeviceV2(object):
-    def __init__(self, address="192.168.0.69", port=50010, autoconnect=True):
+    def __init__(self, address="192.168.0.69", port=50010, autoconnect=True, timeout=SOCKET_TIMEOUT):
         self._address = address
         self._port = port
+        self._timeout = timeout
         self._autoconnect = autoconnect
         self._pcic = None
         self._rpc = None
 
     def __enter__(self):
-        self._pcic = O2x5xxPCICDevice(address=self._address, port=self._port, autoconnect=self._autoconnect)
+        self._pcic = O2x5xxPCICDevice(address=self._address, port=self._port, autoconnect=self._autoconnect,
+                                      timeout=self._timeout)
         self._rpc = O2x5xxRPCDevice(address=self._address)
         return self
 

--- a/source/pcic/client.py
+++ b/source/pcic/client.py
@@ -8,12 +8,12 @@ import json
 import re
 import io
 
-SOCKET_TIMEOUT = 5
+SOCKET_TIMEOUT = 10
 
 
 class Client(object):
 
-    def __init__(self, address, port, autoconnect=True, timeout=5):
+    def __init__(self, address, port, autoconnect=True, timeout=SOCKET_TIMEOUT):
         self.address = address
         self.port = port
         self.autoconnect = autoconnect
@@ -35,6 +35,7 @@ class Client(object):
         """
         if not self.connected:
             self.pcicSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.pcicSocket.settimeout(self.timeout)
             self.pcicSocket.connect((self.address, self.port))
             self.connected = True
 
@@ -72,6 +73,27 @@ class Client(object):
             data = data + data_part
         self.recv_counter += number_bytes
         return data
+
+    @property
+    def pcic_socket_timeout(self) -> float:
+        """
+		Getter for timeout value of lowlevel connection socket.
+
+		:return: (float) socket timeout in seconds
+		"""
+        return self.timeout
+
+    @pcic_socket_timeout.setter
+    def pcic_socket_timeout(self, value: float) -> None:
+        """
+        Setter for timeout value of lowlevel connection socket.
+
+        :param value: (float) in seconds.
+        :return: None
+        """
+        if self.pcicSocket:
+            self.pcicSocket.settimeout(value)
+        self.timeout = value
 
 
 class PCICV3Client(Client):


### PR DESCRIPTION
Fixes problem with PCIC socket, in which recv was waiting for very long time until server return data from I01? command. If user have bad network connection or there is a bug on the server side, it would wait forever. Timeout of 10s fixes this issue.