### PR TITLE
Fix dangling autoheartbeat

### DIFF
--- a/source/rpc/proxy.py
+++ b/source/rpc/proxy.py
@@ -136,6 +136,13 @@ class SessionProxy(BaseProxy):
         self.autoHeartbeatTimer = Timer(self.autoHeartbeatInterval - 1, self.doAutoHeartbeat)
         self.autoHeartbeatTimer.start()
 
+    def cancelSession(self):
+        if self.autoHeartbeatTimer != None:
+            self.autoHeartbeatTimer.cancel()
+            self.autoHeartbeatTimer.join()
+            self.autoHeartbeatTimer = None
+        self.proxy.cancelSession()
+
     @contextmanager
     def setOperatingMode(self, mode, timeout=SOCKET_TIMEOUT):
         """Generator for setOperatingMode to be used in with statement.

--- a/source/rpc/session.py
+++ b/source/rpc/session.py
@@ -252,7 +252,7 @@ class Session(object):
         Method for closing the session.
         :return: None
         """
-        self._sessionProxy.proxy.cancelSession()
+        self._sessionProxy.cancelSession()
         self._sessionProxy.close()
         self._sessionProxy = None
         self._device._sessionURL = None


### PR DESCRIPTION
If you have created your session "directly" (not using the context managed session), i.e. like

	dev = o2x5xx.device.O2x5xxDeviceV2("192.168.0.69")
	session = dev.rpc.requestSession()

then a subsequent session.cancelSession() does not cancel the autoheartbeat timer that is still running, leading later to errors like

Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 1378, in run
    self.function(*self.args, **self.kwargs)
  File "/proj/o2x5xx-python/source/rpc/proxy.py", line 133, in doAutoHeartbeat
    newHeartbeatInterval = self.heartbeat(self.autoHeartbeatInterval)
  File "/proj/o2x5xx-python/source/rpc/proxy.py", line 123, in heartbeat
    result = self.proxy.heartbeat(heartbeatInterval)
AttributeError: 'NoneType' object has no attribute 'heartbeat'

The solution is to add an explicit cancelSession() method to the proxy where the running timer gets cancelled as well.